### PR TITLE
switch pkgdown deployment to gh-pages branch

### DIFF
--- a/.github/workflows/build-pkgdown-site.yml
+++ b/.github/workflows/build-pkgdown-site.yml
@@ -1,5 +1,6 @@
 on:
   push:
+      branches: none
 name: update-pkgdown-site
 
 jobs:
@@ -11,13 +12,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-pandoc@v2
-      
+
       - name: Install R package linux dependencies
-        run: |        
+        run: |
           sudo apt update
           sudo apt-get install libcurl4-openssl-dev libnetcdf-dev libudunits2-dev libgdal-dev libharfbuzz-dev libfribidi-dev
         shell: bash
-        
+
       - name: Install R packages
         run: Rscript -e 'install.packages(c("pkgdown", "roxygen2", "pkgload", "withr", "knitr", "raster", "sf"))'
 

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -1,0 +1,55 @@
+name: gh-pages
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+
+jobs:
+  pkgdown:
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+
+      - name: Install binary dependencies
+        if: runner.os != 'Linux'
+        run: |
+          remotes::install_deps(dependencies = TRUE, type="binary")
+        shell: Rscript {0}
+
+      - name: Install pkgdown
+        run: |
+          install.packages("pkgdown", type = "binary")
+        shell: Rscript {0}
+
+      - name: Install package
+        run: R CMD INSTALL .
+
+      - name: Deploy package
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'


### PR DESCRIPTION
Switch pkgdown deployment to gh-pages branch rather than the docs folder.

* added `pkgdown.yml`

Done: This is reliant on NEFSC IT to change repo settings (i have no privileges, ticket made )

When this is working we will delete the `docs` folder and .gitignore it. (This will prevent users from having to deal with files in the `doc` showing diffs when bulding the site locally using `pkgdown::build_site()`)

